### PR TITLE
Switch to multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM node:18-alpine3.17
-ENV NODE_ENV=production
+FROM node:18-alpine3.18 as builder
 WORKDIR /usr/src/app
-COPY ["package.json", "package-lock.json*", "npm-shrinkwrap.json*", "./"]
-RUN npm install --production --silent 
-RUN mv node_modules ../
-COPY . .
+COPY ["package.json", "package-lock.json*", "index.js", "./"]
+RUN npm install --omit=dev
+
+FROM alpine:3.18 as deploy
+RUN apk add --no-cache nodejs
+COPY --from=builder /usr/src/app /app
+WORKDIR /app
 EXPOSE 3000
-CMD ["npm", "start"]
+CMD ["node", "index.js"]


### PR DESCRIPTION
This PR implements a multi-stage build for the docker image. This way, the deploy image does not need to be the big "node:alpine" image, but can be the tiny "alpine" directly. **This reduces the final image size from ~206MB to ~71 MB**

After the app is built, only the `/app` dir is copied to the final image.
Additional changes:
 - There is no need to copy `node_modules` from the repo into the image, as the modules are build during `npm install`
 - There is no need to copy `.` into the image - all that is needed is `package.json`, `package-lock.json` and `index.js`
 - Update alpine3.17 to alpine3.18