### PR TITLE
Fix for seperate 'currently running' message

### DIFF
--- a/.dev-docker-compose.yml
+++ b/.dev-docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  monocker:
+    container_name: monocker
+    image: monocker
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    environment:
+      SERVER_LABEL: $SERVER_LABEL
+      SERVER_AVATAR: $SERVER_AVATAR
+      DOCKER_HOST: $DOCKER_HOST
+      MESSAGE_PLATFORM: $MESSAGE_PLATFORM
+      LABEL_ENABLE: $LABEL_ENABLE
+      ONLY_OFFLINE_STATES: $ONLY_OFFLINE_STATES
+      EXCLUDE_EXITED: $EXCLUDE_EXITED
+      PERIOD: $PERIOD
+      DISABLE_STARTUP_MSG: $DISABLE_STARTUP_MSG
+
+      CUSTOM_NTFY_SERVER: $CUSTOM_NTFY_SERVER 
+      NTFY_USER: $NTFY_USER 
+      NTFY_PASS: $NTFY_PASS
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    restart: unless-stopped
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       DISABLE_STARTUP_MSG: 'false'
 
       ## ADVANCED NTFY SETTINGS
-      # CUSTOM_NTFY_SERVER: 'https://ntfy.nesretep.net' # use your own NTFY server
+      # CUSTOM_NTFY_SERVER: 'https://ntfy.yourdomain.net' # use your own NTFY server
       # NTFY_USER: 'user' # use a username and password to login (on ntfy.sh or your own server)
       # NTFY_PASS: 'psw' 
     volumes:

--- a/index.js
+++ b/index.js
@@ -66,17 +66,6 @@ console.log(`Monitoring started
      - Display SHA ID: ` + SHA);
 
 console.log()
-if(DISABLE_STARTUP_MSG.toLowerCase()!='true'){
-    send(`Monitoring started 
-        -- Version: ` + pjson.version + `
-        -- Messaging platform: ` + MESSAGE_PLATFORM.split("@")[0] +`
-        -- Polling period: ` + PERIOD + ` seconds` +`
-        -- Only offline state monitoring: ` + ONLY_OFFLINE_STATES +`
-        -- Only include labelled containers: ` + LABEL_ENABLE +`
-        -- Do not monitor 'Exited': ` + EXCLUDE_EXITED +`
-        -- Disable Startup Messages: ` + DISABLE_STARTUP_MSG +` 
-        -- Display SHA ID: ` + SHA);
-}
 
 async function sendTelegram(message) {
     let notify = new Telegram({ token: msgDetails[1], chatId: msgDetails[2] });
@@ -268,6 +257,16 @@ async function list() {
             console.log("     - Currently monitoring " + newConArray.length + " (running) containers");
             if(DISABLE_STARTUP_MSG.toLowerCase()!='true'){
                 //send("Currently monitoring " + newConArray.length + " (running) containers");
+                messages =`Monitoring started 
+                -- Version: ` + pjson.version + `
+                -- Messaging platform: ` + MESSAGE_PLATFORM.split("@")[0] +`
+                -- Polling period: ` + PERIOD + ` seconds` +`
+                -- Only offline state monitoring: ` + ONLY_OFFLINE_STATES +`
+                -- Only include labelled containers: ` + LABEL_ENABLE +`
+                -- Do not monitor 'Exited': ` + EXCLUDE_EXITED +`
+                -- Disable Startup Messages: ` + DISABLE_STARTUP_MSG +` 
+                -- Display SHA ID: ` + SHA +`
+                `;
                 messages += "Currently monitoring " + newConArray.length + " (running) containers" + "\r\n";
             }
             isFirstRun=false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monocker",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "description": "Monitors and alerts for docker containers state changes",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
This eliminates the seperate message for the initial 'currently running' messages, on startup. 